### PR TITLE
Remove duplicate env line from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 
 # Local environment file (your API keys)
 .env
-.env


### PR DESCRIPTION
## Summary
- tidy `.gitignore` by removing the second `.env` entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b82344348326ad3b9751d92de6ce