### PR TITLE
Fix PWA icon references

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <meta name="theme-color" content="#0066cc" />
 
   <!-- iOS support: icon when saving to Home Screen -->
-  <link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7gr5cAAAAASUVORK5CYII=" />
+  <link rel="apple-touch-icon" href="icons/icon-192.png" />
   <!-- Allow your PWA to run standalone on iOS -->
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <!-- iOS status bar style when your PWA is launched -->

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   "background_color": "#ffffff",
   "theme_color": "#0066cc",
   "icons": [
-    { "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7gr5cAAAAASUVORK5CYII=", "sizes": "192x192", "type": "image/png" },
-    { "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7gr5cAAAAASUVORK5CYII=", "sizes": "512x512", "type": "image/png" }
+    { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
   ]
 }


### PR DESCRIPTION
## Summary
- reference real icon assets for iOS and manifest

## Testing
- `grep -n "data:image" -R`

------
https://chatgpt.com/codex/tasks/task_e_6841a8136af0832682f1ddfae7e68b19