### PR TITLE
Fix layout overflow on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,14 @@
+/* Apply border-box sizing globally to avoid layout issues */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  overflow-x: hidden;
+}
+
 body {
   margin: 0;
   overflow-x: hidden;


### PR DESCRIPTION
## Summary
- add universal `box-sizing: border-box` rule
- hide horizontal overflow on the `html` element

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841e3e92aa48326a577de1cc1a8b280