### PR TITLE
Fix mobile zoom issue on input

### DIFF
--- a/style.css
+++ b/style.css
@@ -59,3 +59,9 @@ body {
 .input-area input {
   flex: 1;
 }
+
+/* Prevent zooming on focus in iOS */
+input,
+textarea {
+  font-size: 16px;
+}


### PR DESCRIPTION
## Summary
- set input and textarea base font size to keep iOS from zooming

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841e7dd738c83269699460e778f8603