### PR TITLE
Fix chat box width to stop horizontal scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -69,6 +69,7 @@ input,
 /* Ensure chat messages don't overflow the viewport */
 .chat-box {
   padding: 10px;
+  width: 100%;
   max-width: 100%;
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
## Summary
- ensure `.chat-box` always fits the viewport

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841ed8a22a0832691a4a8c999e5ea02