### PR TITLE
Fix guidelines overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,8 +16,21 @@ body {
 
 #prep-guidelines {
   background-color: #eef;
-  padding: 10px;
+  padding: 1rem;
   border-bottom: 1px solid #ccc;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+#prep-guidelines ul {
+  padding-left: 1.5rem;
+  margin: 0;
+}
+#prep-guidelines li {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 #prep-guidelines button {
   margin-top: 5px;


### PR DESCRIPTION
## Summary
- ensure the prep guidelines element doesn't cause horizontal scrolling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f197833883268b81cb8c32f47228