### PR TITLE
Fix iOS zoom on chat input

### DIFF
--- a/style.css
+++ b/style.css
@@ -76,11 +76,11 @@ body {
   flex: 1;
 }
 
-/* Prevent zooming on focus in iOS */
+/* Prevent zooming on focus in iOS by ensuring at least 16px font size */
 input,
-  textarea {
-    font-size: 1rem;
-  }
+textarea {
+  font-size: 16px;
+}
 
 /* Ensure chat messages don't overflow the viewport */
 .chat-box {


### PR DESCRIPTION
## Summary
- prevent mobile browsers from zooming in when the input is focused by bumping the base font size of text fields to 16px

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f708a0d88326af69ae02cae78493